### PR TITLE
Add fix for same-line closing bracket in lookup. Update FailureThrowa…

### DIFF
--- a/failures-gen-sample/build.gradle
+++ b/failures-gen-sample/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath 'com.google.protobuf:protobuf-java:3.0.0-beta-2'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.4'
-        classpath "org.spine3.tools:protobuf-plugin:1.3.1"
+        classpath "org.spine3.tools:protobuf-plugin:1.3.2"
     }
 }
 

--- a/protobuf-plugin/build.gradle
+++ b/protobuf-plugin/build.gradle
@@ -1,5 +1,5 @@
 group 'org.spine3.tools'
-version '1.3.1'
+version '1.3.2'
 
 apply plugin: 'maven'
 apply plugin: 'groovy'

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/failures/FailureWriter.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/failures/FailureWriter.groovy
@@ -70,7 +70,7 @@ import groovy.util.logging.Slf4j
     }
 
     private static void writeImports(OutputStreamWriter writer) {
-        writer.write("import org.spine3.server.FailureThrowable;\n");
+        writer.write("import org.spine3.server.failure.FailureThrowable;\n");
         writer.write("\n");
     }
 

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/ProtoLookupPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/ProtoLookupPlugin.groovy
@@ -153,9 +153,11 @@ class ProtoLookupPlugin implements Plugin<Project> {
                 protoPackage = findLineData(trimmedLine, PROTO_PACKAGE_PATTERN) + ".";
             }
             // This won't work for bad-formatted proto files. Consider moving to descriptors.
+            // Again, won' work for }} case, move to descriptors instead of fixing
             if (trimmedLine.contains(OPENING_BRACKET)) {
                 nestedClassDepth++;
-            } else if (trimmedLine.contains(CLOSING_BRACKET)) {
+            }
+            if (trimmedLine.contains(CLOSING_BRACKET)) {
                 nestedClassDepth--;
             }
         }


### PR DESCRIPTION
…ble path for generated failures. Upgrade version to 1.3.2. Already published.

Please note that now generated failures won't work for old server artifact (older than yesterday). For older artifacts continue using 1.3.1.