### PR TITLE
Migrate to Gradle 2.13.

### DIFF
--- a/entity-lookup-sample/build.gradle
+++ b/entity-lookup-sample/build.gradle
@@ -11,8 +11,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-java:3.0.0-beta-2'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.0'
-        classpath "org.spine3.tools:protobuf-plugin:1.3.3"
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7'
+        classpath "org.spine3.tools:protobuf-plugin:1.4"
     }
 }
 

--- a/failures-gen-sample/build.gradle
+++ b/failures-gen-sample/build.gradle
@@ -11,8 +11,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-java:3.0.0-beta-2'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.4'
-        classpath "org.spine3.tools:protobuf-plugin:1.3.3"
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7'
+        classpath "org.spine3.tools:protobuf-plugin:1.4"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/protobuf-plugin/build.gradle
+++ b/protobuf-plugin/build.gradle
@@ -1,5 +1,5 @@
 group 'org.spine3.tools'
-version '1.3.3'
+version '1.4'
 
 apply plugin: 'maven'
 apply plugin: 'groovy'

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/failures/FailuresGenPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/failures/FailuresGenPlugin.groovy
@@ -26,11 +26,11 @@ class FailuresGenPlugin implements Plugin<Project> {
         projectPath = target.projectDir.absolutePath;
 
         final Task generateFailures = target.task("generateFailures") << {
-            processDescriptors(readFailureDescriptorsMain(target));
+            processDescriptors(readFailureDescriptors("main", false));
         };
 
         final Task generateTestFailures = target.task("generateTestFailures") << {
-            processDescriptors(readFailureDescriptorsTest(target));
+            processDescriptors(readFailureDescriptors("test", true));
         };
 
         generateFailures.dependsOn("generateProto");
@@ -50,22 +50,9 @@ class FailuresGenPlugin implements Plugin<Project> {
         }
     }
 
-    private List<FileDescriptorProto> readFailureDescriptorsMain(Project target) {
-        final String filePath = "${target.projectDir.absolutePath}/build/descriptors/main.desc";
-        final boolean noDescriptorsWarning = true;
-
-        readFailureDescriptors(filePath, noDescriptorsWarning);
-    }
-
-    private List<FileDescriptorProto> readFailureDescriptorsTest(Project target) {
-        final String filePath = "${target.projectDir.absolutePath}/build/descriptors/test.desc";
-        final boolean noDescriptorsWarning = false;
-
-        readFailureDescriptors(filePath, noDescriptorsWarning);
-    }
-
-    private List<FileDescriptorProto> readFailureDescriptors(String descFilePath,
-                                                                              boolean noDescriptorsWarning) {
+    private List<FileDescriptorProto> readFailureDescriptors(String descSourceSet,
+                                                             boolean noDescriptorsWarning) {
+        final String descFilePath = "${projectPath}/build/descriptors/${descSourceSet}.desc";
         final List<FileDescriptorProto> failureDescriptors = new ArrayList<>();
 
         if (!new File(descFilePath).exists()) {

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/entity/EntityLookupPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/entity/EntityLookupPlugin.groovy
@@ -44,16 +44,17 @@ public class EntityLookupPlugin implements Plugin<Project> {
     void apply(Project project) {
         this.project = project;
         final Task findEntitiesTask = project.task("findEntities") {
-            findEntities();
+            findEntityFilesAndWriteProps("main");
         }
-        findEntitiesTask.dependsOn("compileJava", "generateProto", "generateTestProto");
+        final Task findTestEntitiesTask = project.task("findTestEntities") {
+            findEntityFilesAndWriteProps("test");
+        }
+        findEntitiesTask.dependsOn("compileJava");
+        findTestEntitiesTask.dependsOn("compileTestJava");
         final Task processResources = project.getTasks().getByPath("processResources");
+        final Task processTestResources = project.getTasks().getByPath("processTestResources");
         processResources.dependsOn(findEntitiesTask);
-    }
-
-    private void findEntities() {
-        findEntityFilesAndWriteProps("main");
-        findEntityFilesAndWriteProps("test");
+        processTestResources.dependsOn(findTestEntitiesTask);
     }
 
     private void findEntityFilesAndWriteProps(String mainOrTest) {

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/proto/ProtoToJavaMapperPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/proto/ProtoToJavaMapperPlugin.groovy
@@ -58,25 +58,21 @@ class ProtoToJavaMapperPlugin implements Plugin<Project> {
     public void apply(Project project) {
 
         final Task scanProtosTask = project.task("scanProtos") << {
-            scanProtos(project);
+            scanRootDir(project, "main");
         };
 
-        scanProtosTask.dependsOn("compileJava", "generateProto", "generateTestProto");
+        final Task scanTestProtosTask = project.task("scanTestProtos") << {
+            scanRootDir(project, "test");
+        };
+
+        scanProtosTask.dependsOn("generateProto");
+        scanTestProtosTask.dependsOn("generateTestProto");
 
         final Task processResources = project.getTasks().getByPath("processResources");
+        final Task processTestResources = project.getTasks().getByPath("processTestResources");
+
         processResources.dependsOn(scanProtosTask);
-    }
-
-    private static void scanProtos(Project target) {
-
-        final String projectPath = target.projectDir.absolutePath;
-
-        log.debug("${ProtoToJavaMapperPlugin.class.getSimpleName()}: start");
-        log.debug("${ProtoToJavaMapperPlugin.class.getSimpleName()}: Project path: ${projectPath}");
-
-        for (String rootDirPathSuffix : ["main", "test"]) {
-            scanRootDir(target, rootDirPathSuffix)
-        }
+        processTestResources.dependsOn(scanTestProtosTask);
     }
 
     private static void scanRootDir(Project target, String rootDirPathSuffix) {


### PR DESCRIPTION
Dependencies were updated, main/test operations were split to support new task lifecycle (e.g. we could depend something both on generateProto and generateTestProto and depend compileJava on this task, but now we can't)