### PR TITLE
Allow underscores in Protobuf package names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 *.class
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
 # Package Files #
 *.jar
 *.war

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ hs_err_pid*
 
 credentials.properties
 
+gradle.properties
+
 */generated/*
 
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,16 @@ subprojects {
     apply plugin: 'idea'
     apply plugin: 'maven-publish'
 
+    sourceCompatibility = 1.7;
+    targetCompatibility = 1.7;
+
+    // Set Java home to point to JDK7 in gradle.properties file.
+    //
+    // For Mac OS X, it looks like this:
+    //
+    // # suppress inspection "UnusedProperty"
+    // org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/
+
     repositories {
         mavenCentral()
     }

--- a/protobuf-plugin/build.gradle
+++ b/protobuf-plugin/build.gradle
@@ -1,5 +1,5 @@
 group 'org.spine3.tools'
-version '1.4.2'
+version '1.4.3'
 
 apply plugin: 'maven'
 apply plugin: 'groovy'

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/proto/ProtoToJavaMapperPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/lookup/proto/ProtoToJavaMapperPlugin.groovy
@@ -52,7 +52,7 @@ class ProtoToJavaMapperPlugin implements Plugin<Project> {
     private static final String NAME_REGEX = "([a-zA-Z0-9]*) *\\{";
     private static final Pattern MESSAGE_PATTERN = Pattern.compile(MESSAGE_PREFIX + NAME_REGEX);
     private static final Pattern JAVA_PACKAGE_PATTERN = Pattern.compile(JAVA_PACKAGE_PREFIX + " *= *\\\"(.*)\\\";*");
-    private static final Pattern PROTO_PACKAGE_PATTERN = Pattern.compile(PROTO_PACKAGE_PREFIX + "([a-zA-Z0-9.]*);*");
+    private static final Pattern PROTO_PACKAGE_PATTERN = Pattern.compile(PROTO_PACKAGE_PREFIX + "([a-zA-Z0-9_.]*);*");
 
     @Override
     public void apply(Project project) {


### PR DESCRIPTION
We need this for supporting `spine_examples` package, which must be external to the framework.
This PR advances the version to 1.4.3. 
This version has been used in branches in Spine already.