### PR TITLE
Reimplement ProtoToJavaMapper plugin using descriptors

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -39,7 +39,7 @@
       <option name="m_minLength" value="8" />
       <option name="m_maxLength" value="64" />
     </inspection_tool>
-    <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="GroovyLocalVariableNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_regex" value="[a-z][A-Za-z\d]*" />
       <option name="m_minLength" value="1" />
       <option name="m_maxLength" value="32" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-//noinspection GroovyLocalVariableNamingConvention
-final String CREDENTIALS_FILE_PATH = "credentials.properties"
-
-apply plugin: 'maven'
 
 allprojects {
     group = 'org.spine3.tools'
@@ -12,6 +8,7 @@ allprojects {
     }
 }
 
+final String CREDENTIALS_FILE_PATH = "credentials.properties"
 def repositoryUserName = null
 def repositoryUserPassword = null
 Properties properties = new Properties()
@@ -53,18 +50,24 @@ subprojects {
         }
     }
 
+    final String SRC_DIR = "$projectDir/plugin/src"
+
     sourceSets {
         main {
-            resources.srcDirs += files("plugin/src/main/resources")
-            groovy.srcDirs = ["plugin/src/main/groovy"]
+            groovy.srcDirs += "$SRC_DIR/main/groovy"
+            resources.srcDirs += "$SRC_DIR/main/resources"
+        }
+        test {
+            groovy.srcDirs += "$SRC_DIR/test/groovy"
+            resources.srcDirs += "$SRC_DIR/test/resources"
         }
     }
 
     publishing {
         publications {
             mavenJava(MavenPublication) {
-                groupId "${group}"
-                artifactId "${project.name}"
+                groupId "$group"
+                artifactId "$project.name"
                 version "${project.version}"
 
                 from components.java
@@ -75,8 +78,8 @@ subprojects {
         repositories {
             maven {
                 credentials {
-                    username "${repositoryUserName}"
-                    password "${repositoryUserPassword}"
+                    username "$repositoryUserName"
+                    password "$repositoryUserPassword"
                 }
                 url "${project.MAVEN_REPOSITORY_URL}"
             }

--- a/failures-gen-sample/build.gradle
+++ b/failures-gen-sample/build.gradle
@@ -4,34 +4,35 @@ version '1.0'
 buildscript {
     repositories {
         mavenLocal()
+        mavenCentral()
         maven {
             url = "${project.MAVEN_REPOSITORY_URL}"
         }
-        mavenCentral()
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-java:3.0.0-beta-2'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.7'
         classpath "org.spine3.tools:protobuf-plugin:1.4.8"
     }
+    configurations.all({
+        resolutionStrategy.cacheChangingModulesFor(0, 'seconds')
+    })
 }
 
 apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
-apply plugin: 'idea'
-
 apply plugin: 'org.spine3.tools.protobuf-plugin'
 
 repositories {
     mavenLocal()
     maven {
-        url = "${project.MAVEN_REPOSITORY_URL}"
+        url = "$MAVEN_REPOSITORY_URL"
     }
     mavenCentral()
 }
 
 dependencies {
-    compile "org.spine3:server:${project.SPINE_VERSION}"
+    compile "org.spine3:server:$SPINE_VERSION"
     compile 'com.google.protobuf:protobuf-java:3.0.0-beta-2'
 }
 

--- a/protobuf-plugin/build.gradle
+++ b/protobuf-plugin/build.gradle
@@ -1,28 +1,6 @@
 group 'org.spine3.tools'
 version '1.4.8'
 
-apply plugin: 'maven'
-apply plugin: 'groovy'
-apply plugin: 'idea'
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-
     compile 'com.google.protobuf:protobuf-java:3.0.0-beta-3'
-}
-
-sourceSets {
-    main {
-        resources.srcDirs += files('plugin/src/main/resources')
-        groovy.srcDirs += ['plugin/src/main/groovy']
-    }
-    main {
-        resources.srcDirs += files('plugin/src/test/resources')
-        groovy.srcDirs += ['plugin/src/test/groovy']
-    }
 }

--- a/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/protobuf/failures/FailuresGenPlugin.groovy
+++ b/protobuf-plugin/plugin/src/main/groovy/org/spine3/gradle/protobuf/failures/FailuresGenPlugin.groovy
@@ -19,6 +19,7 @@
  */
 
 package org.spine3.gradle.protobuf.failures
+
 import groovy.util.logging.Slf4j
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -27,6 +28,7 @@ import org.gradle.api.Task
 import static com.google.protobuf.DescriptorProtos.*
 import static org.spine3.gradle.protobuf.Extension.*
 import static org.spine3.gradle.protobuf.util.DescriptorSetUtil.getProtoFileDescriptors
+
 /**
  * Plugin which generates Failures, based on failures.proto files.
  *

--- a/protobuf-plugin/plugin/src/test/groovy/org/spine3/gradle/protobuf/Given.groovy
+++ b/protobuf-plugin/plugin/src/test/groovy/org/spine3/gradle/protobuf/Given.groovy
@@ -54,7 +54,6 @@ class Given {
     /** Creates a project with all required tasks. */
     static Project newProject() {
         final Project project = ProjectBuilder.builder()
-                .withProjectDir(new File("testProject"))
                 .build()
         project.task(CLEAN)
         project.task(PROCESS_RESOURCES)

--- a/reflections-plugin/build.gradle
+++ b/reflections-plugin/build.gradle
@@ -3,33 +3,8 @@ description = "Gradle port for Maven Reflections Plugin."
 group 'org.spine3'
 version '1.0'
 
-apply plugin: 'idea'
-apply plugin: 'groovy'
-apply plugin: 'maven'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
-
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-
     compile 'org.reflections:reflections:0.9.10'
     compile 'dom4j:dom4j:1.6.1'
-
     compile 'org.codehaus.groovy:groovy-all:2.4.4'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-}
-
-sourceSets {
-    main {
-        resources.srcDirs += files('plugin/src/main/resources')
-        groovy.srcDirs += ['plugin/src/main/groovy']
-    }
-    main {
-        resources.srcDirs += files('plugin/src/test/resources')
-        groovy.srcDirs += ['plugin/src/test/groovy']
-    }
 }

--- a/reflections-plugin/plugin/src/test/groovy/org/spine3/gradle/protobuf/Given.groovy
+++ b/reflections-plugin/plugin/src/test/groovy/org/spine3/gradle/protobuf/Given.groovy
@@ -39,7 +39,6 @@ class Given {
     /** Creates a project with all required tasks. */
     static Project newProject() {
         final Project project = ProjectBuilder.builder()
-                .withProjectDir(new File("testProject"))
                 .build()
         project.task(CLASSES_TASK)
         project.task(BUILD_TASK)


### PR DESCRIPTION
To avoid .proto files parsing.