### PR TITLE
Groovy-to-Java migration fixes.

### DIFF
--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
@@ -66,13 +66,20 @@ public class FailureWriter {
             .put(FieldDescriptorProto.Type.TYPE_FIXED32.name(), "int")
             .put(FieldDescriptorProto.Type.TYPE_BOOL.name(), "boolean")
             .put(FieldDescriptorProto.Type.TYPE_STRING.name(), "String")
-            .put(FieldDescriptorProto.Type.TYPE_GROUP.name(), null) // GROUPS ARE NOT SUPPORTED
             .put(FieldDescriptorProto.Type.TYPE_BYTES.name(), "com.google.protobuf.ByteString")
             .put(FieldDescriptorProto.Type.TYPE_UINT32.name(), "int")
             .put(FieldDescriptorProto.Type.TYPE_SFIXED32.name(), "int")
             .put(FieldDescriptorProto.Type.TYPE_SFIXED64.name(), "long")
             .put(FieldDescriptorProto.Type.TYPE_SINT32.name(), "int")
             .put(FieldDescriptorProto.Type.TYPE_SINT64.name(), "int")
+
+            /**
+             * Groups are NOT supported, so do not create an associated Java type for it.
+             * The return value for the {@link FieldDescriptorProto.Type.TYPE_GROUP} key
+             * is intended to be {@code null}.
+             **/
+            //.put(FieldDescriptorProto.Type.TYPE_GROUP.name(), "not supported")
+
             .build();
 
     /**

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/lookup/proto/ProtoToJavaTypeMapper.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/lookup/proto/ProtoToJavaTypeMapper.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newLinkedList;
 import static org.spine3.gradle.protobuf.util.UnknownOptions.getUnknownOptionValue;
 
@@ -200,7 +201,7 @@ public class ProtoToJavaTypeMapper {
 
     private static String getTypeUrlPrefix(FileDescriptorProto file) {
         final String typeUrlPrefix = getUnknownOptionValue(file, OPTION_NUMBER_TYPE_URL_PREFIX);
-        final String prefix = typeUrlPrefix.isEmpty() ? GOOGLE_TYPE_URL_PREFIX : typeUrlPrefix;
+        final String prefix = isNullOrEmpty(typeUrlPrefix) ? GOOGLE_TYPE_URL_PREFIX : typeUrlPrefix;
         final String result = (prefix + PROTO_TYPE_URL_SEPARATOR);
         return result;
     }


### PR DESCRIPTION
Summary of changes:
* changed an `ImmutableMap` initialization — avoid `null` value.
* added another check for `null` value — as Java throws NPE instead of ignoring the statement (as in Groovy).

The artifact version remains the same.