### PR TITLE
Require `Command` message and context for the `Failure` construction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 final SPINE_VERSION = '0.8.0'
-final PLUGIN_VERSION = '0.7.24-SNAPSHOT'
-final PLUGIN_PUBLISH_VERSION = '0.8.0'
+final PLUGIN_VERSION = '0.8.0'
+final PLUGIN_PUBLISH_VERSION = '0.8.1-SNAPSHOT'
 
 buildscript {
     ext {

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
@@ -75,7 +75,7 @@ public class FailureWriter {
             .put(FieldDescriptorProto.Type.TYPE_SINT32.name(), "int")
             .put(FieldDescriptorProto.Type.TYPE_SINT64.name(), "int")
 
-            /**
+            /*
              * Groups are NOT supported, so do not create an associated Java type for it.
              * The return value for the {@link FieldDescriptorProto.Type.TYPE_GROUP} key
              * is intended to be {@code null}.
@@ -140,6 +140,8 @@ public class FailureWriter {
         log().debug("Writing the imports");
 
         writer.write("import org.spine3.base.FailureThrowable;\n");
+        writer.write("import com.google.protobuf.GeneratedMessageV3;\n");
+        writer.write("import org.spine3.base.CommandContext;\n");
         writer.write("\n");
     }
 
@@ -156,8 +158,8 @@ public class FailureWriter {
         log().debug("Writing getFailure()");
 
         writer.write("\n\t@Override\n");
-        writer.write("\tpublic " + outerClassName + '.' + className + " getFailure() {\n");
-        writer.write("\t\treturn (" + outerClassName + '.' + className + ") super.getFailure();\n\t}\n");
+        writer.write("\tpublic " + outerClassName + '.' + className + " getFailureMessage() {\n");
+        writer.write("\t\treturn (" + outerClassName + '.' + className + ") super.getFailureMessage();\n\t}\n");
     }
 
     @SuppressWarnings("MethodWithMultipleLoops")
@@ -165,7 +167,15 @@ public class FailureWriter {
         log().debug("Writing the constructor");
 
         writer.write("\tpublic " + className + '(');
+
+        final String commandMsgCtorParam = "commandMessage";
+        final String commandContextCtorParam = "ctx";
+        writer.write("GeneratedMessageV3 " + commandMsgCtorParam + ", CommandContext " + commandContextCtorParam);
+
         final Set<Map.Entry<String, String>> fieldsEntries = readFieldValues().entrySet();
+        if(!fieldsEntries.isEmpty()) {
+            writer.write(", ");
+        }
 
         final Iterator<Map.Entry<String, String>> iterator = fieldsEntries.iterator();
         for (int i = 0; i < fieldsEntries.size(); i++) {
@@ -177,7 +187,8 @@ public class FailureWriter {
             }
         }
         writer.write(") {\n");
-        writer.write("\t\tsuper(" + outerClassName + '.' + className + ".newBuilder()");
+        writer.write("\t\tsuper(" +commandMsgCtorParam + ", "+ commandContextCtorParam+", " +
+                             outerClassName + '.' + className + ".newBuilder()");
         for (Map.Entry<String, String> field : fieldsEntries) {
             final String upperCaseName = getJavaFieldName(field.getKey(), true);
             writer.write(".set" + upperCaseName + '(' + getJavaFieldName(field.getKey(), false) + ')');

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailureWriter.java
@@ -46,6 +46,9 @@ import java.util.Set;
 @SuppressWarnings("HardcodedLineSeparator")
 public class FailureWriter {
 
+    private static final String COMMA_SEPARATOR = ", ";
+    private static final String PUBLIC_MEMBER = "\tpublic";
+
     private final DescriptorProto failureDescriptor;
     private final File outputFile;
     private final String javaPackage;
@@ -158,7 +161,7 @@ public class FailureWriter {
         log().debug("Writing getFailure()");
 
         writer.write("\n\t@Override\n");
-        writer.write("\tpublic " + outerClassName + '.' + className + " getFailureMessage() {\n");
+        writer.write(PUBLIC_MEMBER + ' ' + outerClassName + '.' + className + " getFailureMessage() {\n");
         writer.write("\t\treturn (" + outerClassName + '.' + className + ") super.getFailureMessage();\n\t}\n");
     }
 
@@ -166,15 +169,15 @@ public class FailureWriter {
     private void writeConstructor(OutputStreamWriter writer) throws IOException {
         log().debug("Writing the constructor");
 
-        writer.write("\tpublic " + className + '(');
+        writer.write(PUBLIC_MEMBER + ' ' + className + '(');
 
         final String commandMsgCtorParam = "commandMessage";
         final String commandContextCtorParam = "ctx";
         writer.write("GeneratedMessageV3 " + commandMsgCtorParam + ", CommandContext " + commandContextCtorParam);
 
         final Set<Map.Entry<String, String>> fieldsEntries = readFieldValues().entrySet();
-        if(!fieldsEntries.isEmpty()) {
-            writer.write(", ");
+        if (!fieldsEntries.isEmpty()) {
+            writer.write(COMMA_SEPARATOR);
         }
 
         final Iterator<Map.Entry<String, String>> iterator = fieldsEntries.iterator();
@@ -183,11 +186,12 @@ public class FailureWriter {
             writer.write(field.getValue() + ' ' + getJavaFieldName(field.getKey(), false));
             final boolean isNotLast = i != (fieldsEntries.size() - 1);
             if (isNotLast) {
-                writer.write(", ");
+                writer.write(COMMA_SEPARATOR);
             }
         }
         writer.write(") {\n");
-        writer.write("\t\tsuper(" +commandMsgCtorParam + ", "+ commandContextCtorParam+", " +
+        writer.write("\t\tsuper(" + commandMsgCtorParam + COMMA_SEPARATOR +
+                             commandContextCtorParam + COMMA_SEPARATOR +
                              outerClassName + '.' + className + ".newBuilder()");
         for (Map.Entry<String, String> field : fieldsEntries) {
             final String upperCaseName = getJavaFieldName(field.getKey(), true);


### PR DESCRIPTION
**New `Failure` construction**

In order to make `Failure`s more useful, each of them now requires the information on the `Command` which caused it.

The `Command` data is submitted as two newly introduced constructor arguments: 
* the message wrapped by a `Command` (typically, fetched via `command.getMessage()`);
* the context of the `Command` (i.e. `command.getContext()`).

Both arguments are `Serializable` as they extend `GeneratedMessageV3`. That's needed to allow the over-the-wire `Failure` transmission, making it possible to create objects like `FailureBus`.

Before:
```
// throw a failure with the given `Proto` message instance as its state:
throw new SomethingWentWrong(failureState);
```

Now:
```
final DoSomething command = ...
//... it is impossible for some reason, so let's throw a failure now:
throw new SomethingWentWrong(command.getMessage(), command.getContext(), failureState);
```

**Naming changes**

Also, the `getFailure()` method generated by the compiler has been renamed to `getFailureMessage()` — as it returns the `Message`, not the `Failure`.

**Version updates**

The plugin version has been advanced to `0.8.1-SNAPSHOT`.