### PR TITLE
Set proper destination folder for the test `Failure`s generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 final SPINE_VERSION = '0.8.0'
 final PLUGIN_VERSION = '0.8.0'
 
-final PLUGIN_PUBLISH_VERSION = '0.8.2-SNAPSHOT'
+final PLUGIN_PUBLISH_VERSION = '0.8.3-SNAPSHOT'
 
 buildscript {
     ext {

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/Extension.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/Extension.java
@@ -65,6 +65,11 @@ public class Extension {
     public String targetGenFailuresRootDir;
 
     /**
+     * The absolute path to the test target generated failures root directory.
+     */
+    public String targetTestGenFailuresRootDir;
+
+    /**
      * The absolute path to directory to delete.
      *
      * <p>Either this property OR {@code dirsToClean} property is used.
@@ -123,6 +128,16 @@ public class Extension {
         if (path == null || path.isEmpty()) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/generated/main/spine";
+        } else {
+            return path;
+        }
+    }
+
+    public static String getTargetTestGenFailuresRootDir(Project project) {
+        final String path = spineProtobuf(project).targetTestGenFailuresRootDir;
+        if (path == null || path.isEmpty()) {
+            return project.getProjectDir()
+                          .getAbsolutePath() + "/generated/test/spine";
         } else {
             return path;
         }

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/Extension.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/Extension.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonList;
 import static org.spine3.gradle.protobuf.ProtobufPlugin.SPINE_PROTOBUF_EXTENSION_NAME;
 
@@ -85,7 +86,7 @@ public class Extension {
 
     public static String getMainTargetGenResourcesDir(Project project) {
         final String path = spineProtobuf(project).mainTargetGenResourcesDir;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/generated/main/resources";
         } else {
@@ -95,7 +96,7 @@ public class Extension {
 
     public static String getTestTargetGenResourcesDir(Project project) {
         final String path = spineProtobuf(project).testTargetGenResourcesDir;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/generated/test/resources";
         } else {
@@ -105,7 +106,7 @@ public class Extension {
 
     public static String getMainDescriptorSetPath(Project project) {
         final String path = spineProtobuf(project).mainDescriptorSetPath;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/build/descriptors/main.desc";
         } else {
@@ -115,7 +116,7 @@ public class Extension {
 
     public static String getTestDescriptorSetPath(Project project) {
         final String path = spineProtobuf(project).testDescriptorSetPath;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/build/descriptors/test.desc";
         } else {
@@ -125,7 +126,7 @@ public class Extension {
 
     public static String getTargetGenFailuresRootDir(Project project) {
         final String path = spineProtobuf(project).targetGenFailuresRootDir;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/generated/main/spine";
         } else {
@@ -135,7 +136,7 @@ public class Extension {
 
     public static String getTargetTestGenFailuresRootDir(Project project) {
         final String path = spineProtobuf(project).targetTestGenFailuresRootDir;
-        if (path == null || path.isEmpty()) {
+        if (isNullOrEmpty(path)) {
             return project.getProjectDir()
                           .getAbsolutePath() + "/generated/test/spine";
         } else {

--- a/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailuresGenPlugin.java
+++ b/protobuf-plugin/plugin/src/main/java/org/spine3/gradle/protobuf/failures/FailuresGenPlugin.java
@@ -46,6 +46,7 @@ import static org.spine3.gradle.TaskName.GENERATE_TEST_FAILURES;
 import static org.spine3.gradle.TaskName.GENERATE_TEST_PROTO;
 import static org.spine3.gradle.protobuf.Extension.getMainDescriptorSetPath;
 import static org.spine3.gradle.protobuf.Extension.getTargetGenFailuresRootDir;
+import static org.spine3.gradle.protobuf.Extension.getTargetTestGenFailuresRootDir;
 import static org.spine3.gradle.protobuf.Extension.getTestDescriptorSetPath;
 import static org.spine3.gradle.protobuf.util.DescriptorSetUtil.getProtoFileDescriptors;
 
@@ -88,7 +89,7 @@ public class FailuresGenPlugin extends SpinePlugin {
                 final String path = getMainDescriptorSetPath(project);
                 log().debug("Generating the failures from {}", path);
                 final List<FileDescriptorProto> filesWithFailures = getFailureProtoFileDescriptors(path);
-                processDescriptors(filesWithFailures);
+                processDescriptors(filesWithFailures, getTargetGenFailuresRootDir(project));
             }
         };
 
@@ -103,7 +104,7 @@ public class FailuresGenPlugin extends SpinePlugin {
                 final String path = getTestDescriptorSetPath(project);
                 log().debug("Generating the test failures from {}", path);
                 final List<FileDescriptorProto> filesWithFailures = getFailureProtoFileDescriptors(path);
-                processDescriptors(filesWithFailures);
+                processDescriptors(filesWithFailures, getTargetTestGenFailuresRootDir(project));
             }
         };
 
@@ -131,11 +132,11 @@ public class FailuresGenPlugin extends SpinePlugin {
         return result;
     }
 
-    private void processDescriptors(List<FileDescriptorProto> descriptors) {
+    private void processDescriptors(List<FileDescriptorProto> descriptors, String failuresRootDir) {
         log().debug("Processing the file descriptors for the failures {}", descriptors);
         for (FileDescriptorProto file : descriptors) {
             if (isFileWithFailures(file)) {
-                generateFailures(file, messageTypeCache.getCachedTypes());
+                generateFailures(file, messageTypeCache.getCachedTypes(), failuresRootDir);
             } else {
                 log().error("Invalid failures file: {}", file.getName());
             }
@@ -162,9 +163,10 @@ public class FailuresGenPlugin extends SpinePlugin {
         return result;
     }
 
-    private void generateFailures(FileDescriptorProto descriptor, Map<String, String> messageTypeMap) {
+    private static void generateFailures(FileDescriptorProto descriptor,
+                                         Map<String, String> messageTypeMap,
+                                         String failuresRootDir) {
         log().debug("Generating failures form file {}", descriptor.getName());
-        final String failuresRootDir = getTargetGenFailuresRootDir(project);
         final String javaPackage = descriptor.getOptions()
                                              .getJavaPackage();
         final String javaOuterClassName = JavaCode.getOuterClassName(descriptor);


### PR DESCRIPTION
Before this PR, the failures defined in the test sources have been processed incorrectly. Their generation lead to a number of `FailureThrowable` descendants put to the `main` source folder. 

At the same time, the `.proto` messages for the same failures resulted in a number of classes in  the test source folder. As long as `FailureThrowable` classes depend onto the generated `Message`s, the successful compilation was always impossible for the generated content.

This PR is aimed to resolve the issue by setting the `<project>/generated/test/spine` folder as a destination for the test failures.

In scope of this PR the plugin version has been increased to `0.8.3-SNAPSHOT`.
